### PR TITLE
config.assets.enabled was taken out from sprockets-rails v2, simply check if assets are defined

### DIFF
--- a/lib/angular-rails-templates/engine.rb
+++ b/lib/angular-rails-templates/engine.rb
@@ -5,7 +5,7 @@ module AngularRailsTemplates
     config.angular_templates.ignore_prefix = 'templates/'
 
     config.before_initialize do |app|
-      if app.config.assets.enabled
+      if app.config.assets
         require 'sprockets'
         Sprockets::Engines #force autoloading
         Sprockets.register_engine '.ajs', AngularRailsTemplates::Template


### PR DESCRIPTION
see #19
