### PR TITLE
Tell people to //= require angular-rails-templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ gem 'angular-rails-templates'
 Then, in your `application.js` file, require your templates and the internal javascript file:
 
 ```javascript
-//= require angularjs
+//= require_tree ./angularjs
 //= require_tree ./path_to_your_templates
+//= require angular-rails-templates
 ```
+
 
 `path_to_your_templates` is relative to `application.js`.  For example, your templates are under `app/assets/javascripts/my_app/templates` and you then `require_tree ./my_app/templates`
 


### PR DESCRIPTION
In my experiences with angular-rails-templates, I've had to add this to my file that I do something like

``` javascript
//= require_tree ./angular
//= require_tree ./templates
//= require angular-rails-templates
App = angular.module("app", ["templates"]);
```

It clears up the issue, like in #28 of "Module 'templates' is not available" 

My findings is that the instruction should be in the README.

It looks like it was, but got removed here: https://github.com/pitr/angular-rails-templates/commit/fa7230a10a36835cab911766d03986c89ff640ce#diff-04c6e90faac2675aa89e2176d2eec7d8L18
