### PR TITLE
Rails 4 compatibility

### DIFF
--- a/lib/angular-rails-templates/engine.rb
+++ b/lib/angular-rails-templates/engine.rb
@@ -13,6 +13,8 @@ module AngularRailsTemplates
         Sprockets.register_engine HAML_EXT , AngularRailsTemplates::Template
         Sprockets.register_engine '.ajs'   , AngularRailsTemplates::Template
         Sprockets.register_engine '.html'  , AngularRailsTemplates::Template
+
+        app.config.assets.precompile << %r(angular-rails-templates.js)
       end
     end
   end


### PR DESCRIPTION
Was unable to use angular-rails-templates out of the box with Rails 4 as they no longer autoload vendor/assets files from gems.

This adds angular-rails-templates.js to config.assets.precompile on initialize.

Tests still pass.

Thanks
