### PR TITLE
Sprockets Cache Busting

### DIFF
--- a/lib/angular-rails-templates/engine.rb
+++ b/lib/angular-rails-templates/engine.rb
@@ -50,6 +50,14 @@ module AngularRailsTemplates
         # This engine wraps the HTML into JS
         Sprockets.register_engine '.html', AngularRailsTemplates::Template
       end
+
+      # Sprockets Cache Busting
+      # If ART's version or settings change, expire and recompile all assets
+      app.config.assets.version = [
+        app.config.assets.version,
+        'ART',
+        Digest::MD5.hexdigest("#{VERSION}-#{app.config.angular_templates}")
+      ].join '-'
     end
   end
 end


### PR DESCRIPTION
Minor: Silence some harmless Tilt warnings

Automatically expire and recompile all assets when:
- Installing ART
- Updating ART
- Changing ART's Configuration

Ideally, we would only want to expire `.html(.*)` assets, but as far as I can tell, there is no way to get Sprockets to expire _some_ assets. 

I believe this is the root cause behind issues: #47 #46 #40 #32

---

I'd appreciate it if I could be mentioned as one of the gem authors in the gemspec, because I've done a lot of good work hacking on this gem.
