### PR TITLE
Use proper initializer

### DIFF
--- a/lib/angular-rails-templates/engine.rb
+++ b/lib/angular-rails-templates/engine.rb
@@ -21,7 +21,7 @@ module AngularRailsTemplates
     end
 
 
-    config.before_initialize do |app|
+    initializer 'angular-rails-templates' do |app|
       if app.config.assets
         require 'sprockets'
         require 'sprockets/engines' # load sprockets for Rails 3
@@ -44,11 +44,11 @@ module AngularRailsTemplates
             end
           end
 
-          Sprockets.register_engine ".#{ext}", mimeless_engine
+          app.assets.register_engine ".#{ext}", mimeless_engine
         end
 
         # This engine wraps the HTML into JS
-        Sprockets.register_engine '.html', AngularRailsTemplates::Template
+        app.assets.register_engine '.html', AngularRailsTemplates::Template
       end
 
       # Sprockets Cache Busting


### PR DESCRIPTION
Fixes incompatibility with slim-rails 2.1.5 which registers the engine with
Sprockets, this gem apparently uses the wrong superclass when it patches for
the MIME setting, or shouldn't patch at all with already registered engines, which results in broken functionality.

slim-rails 2.1.5 started registering itself with Sprockets and things started to break (404s in the browser, etc).

More detail, root cause examination, comments and better patches are welcome.
