### PR TITLE
Only process assets inside Rails.root/app/assets (issue #58)

### DIFF
--- a/lib/angular-rails-templates/template.rb
+++ b/lib/angular-rails-templates/template.rb
@@ -10,9 +10,11 @@ module AngularRailsTemplates
       'application/javascript'
     end
 
-    # this method is mandatory on Tilt::Template subclasses
     def prepare
-      if configuration.htmlcompressor
+      # we only want to process html assets inside Rails.root/app/assets
+      @asset_inside_rails_root = file.match "#{Rails.root.join 'app', 'assets'}"
+
+      if configuration.htmlcompressor and @asset_inside_rails_root
         @data = compress data
       end
     end
@@ -23,7 +25,11 @@ module AngularRailsTemplates
       locals[:source_file] = "#{scope.pathname}".sub(/^#{Rails.root}\//,'')
       locals[:angular_module] = configuration.module_name
 
-      AngularJsTemplateWrapper.render(scope, locals)
+      if @asset_inside_rails_root
+        AngularJsTemplateWrapper.render(scope, locals)
+      else
+        data
+      end
     end
 
     private


### PR DESCRIPTION
As discussed in #58, angular-rails-templates should only process files in app/assets.

Fixes bugs with:
- Spree has a html file in its asset folder
- respond.js html asset in vendor/assets/javascripts
