### PR TITLE
Require sprockets < 3

### DIFF
--- a/angular-rails-templates.gemspec
+++ b/angular-rails-templates.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties", ">= 3.1"
-  s.add_dependency "sprockets"
+  s.add_dependency "sprockets", "~> 2"
   s.add_dependency "tilt"
 
   s.add_development_dependency "minitest"


### PR DESCRIPTION
Given that #93 is still open, requiring sprockets < 3 will at least prevent `bundle update` from breaking things