### PR TITLE
configurable extension

### DIFF
--- a/lib/angular-rails-templates.rb
+++ b/lib/angular-rails-templates.rb
@@ -3,4 +3,11 @@ require 'angular-rails-templates/engine'
 module AngularRailsTemplates
   autoload :Template, 'angular-rails-templates/template'
   autoload :VERSION,  'angular-rails-templates/version'
+
+  class << self
+    attr_accessor :extension
+  end
 end
+
+AngularRailsTemplates.extension = '.html'
+

--- a/lib/angular-rails-templates/engine.rb
+++ b/lib/angular-rails-templates/engine.rb
@@ -53,7 +53,7 @@ module AngularRailsTemplates
         end
 
         # This engine wraps the HTML into JS
-        app.assets.register_engine '.html', AngularRailsTemplates::Template
+        app.assets.register_engine AngularRailsTemplates.extension, AngularRailsTemplates::Template
       end
 
       # Sprockets Cache Busting

--- a/lib/angular-rails-templates/template.rb
+++ b/lib/angular-rails-templates/template.rb
@@ -36,7 +36,7 @@ module AngularRailsTemplates
 
     def logical_template_path(scope)
       path = scope.logical_path.sub /^(#{configuration.ignore_prefix.join('|')})/, ''
-      "#{path}.html"
+      "#{path}#{AngularRailsTemplates.extension}"
     end
 
     def configuration


### PR DESCRIPTION
I had a conflict with compiling html assets for others gems (for example ckeditor),
because you define new engine for '.html' extension, it's global.
So I needed to make it configurable. This patch allows me to write something like
AngularRailsTemplates.extension = '.thtml'
in initializers to avoid the problem.