### PR TITLE
default to a relative path for inside_paths, and compare asset files using a relative path

### DIFF
--- a/lib/angular-rails-templates/engine.rb
+++ b/lib/angular-rails-templates/engine.rb
@@ -10,7 +10,7 @@ module AngularRailsTemplates
     config.angular_templates.htmlcompressor = false
 
     config.before_configuration do |app|
-      config.angular_templates.inside_paths = [Rails.root.join('app', 'assets')]
+      config.angular_templates.inside_paths = [File.join('app', 'assets')]
 
       # try loading common markups
       %w(erb haml liquid md radius slim str textile wiki).

--- a/lib/angular-rails-templates/template.rb
+++ b/lib/angular-rails-templates/template.rb
@@ -11,8 +11,9 @@ module AngularRailsTemplates
     end
 
     def prepare
+      rel_file_path = Pathname.new(file).relative_path_from(Rails.root).to_s
       # we only want to process html assets inside those specified in configuration.inside_paths
-      @asset_should_be_processed = configuration.inside_paths.any? { |folder| file.match(folder.to_s) }
+      @asset_should_be_processed = configuration.inside_paths.any? { |folder| rel_file_path.match(folder.to_s) }
 
       if configuration.htmlcompressor and @asset_should_be_processed
         @data = compress data


### PR DESCRIPTION
Fixes #100.  This means that the `config.angular_templates` object no longer includes the full path to the deploy directory, so behavior should be consistent across a cluster of servers using timestamp-based deploy directories.  E.g.

```
2.1.5 :001 > Rails.application.config.angular_templates
 => {:module_name=>"templates", :ignore_prefix=>["templates/"], :inside_paths=>["app/assets"], :markups=>["erb", "haml", "str"], :htmlcompressor=>false}
```

is now the same on every server.