### PR TITLE
Fixed bug with html files outside of inside_paths still being processed

### DIFF
--- a/lib/angular-rails-templates/template.rb
+++ b/lib/angular-rails-templates/template.rb
@@ -13,6 +13,10 @@ module AngularRailsTemplates
     def prepare
       # we only want to process html assets inside those specified in configuration.inside_paths
       @asset_should_be_processed = configuration.inside_paths.any? { |folder| file.match(folder.to_s) }
+      unless @asset_should_be_processed
+        @data = nil
+        return
+      end
 
       if configuration.htmlcompressor and @asset_should_be_processed
         @data = compress data
@@ -20,12 +24,11 @@ module AngularRailsTemplates
     end
 
     def evaluate(scope, locals, &block)
-      locals[:html] = escape_javascript data.chomp
-      locals[:angular_template_name] = logical_template_path(scope)
-      locals[:source_file] = "#{scope.pathname}".sub(/^#{Rails.root}\//,'')
-      locals[:angular_module] = configuration.module_name
-
       if @asset_should_be_processed
+        locals[:html] = escape_javascript data.chomp
+        locals[:angular_template_name] = logical_template_path(scope)
+        locals[:source_file] = "#{scope.pathname}".sub(/^#{Rails.root}\//,'')
+        locals[:angular_module] = configuration.module_name
         AngularJsTemplateWrapper.render(scope, locals)
       else
         data


### PR DESCRIPTION
**Summary:** Fixed bug on Rails 3.2x when you have HTML files with `<script>` tags in them. 

When running `rake assets:precompile` I would see the following:

`ExecJS::ProgramError: Unexpected token: operator (<) (line: 1, col: 0, pos: 0)`

This fixes that
 