### PR TITLE
Change inside_paths default value to relative path

### DIFF
--- a/lib/angular-rails-templates/engine.rb
+++ b/lib/angular-rails-templates/engine.rb
@@ -10,7 +10,7 @@ module AngularRailsTemplates
     config.angular_templates.htmlcompressor = false
 
     config.before_configuration do |app|
-      config.angular_templates.inside_paths = [Rails.root.join('app', 'assets')]
+      config.angular_templates.inside_paths = ['app/assets']
 
       # try loading common markups
       %w(erb haml liquid md radius slim str textile wiki).


### PR DESCRIPTION
The reason why we must use relative path for inside_paths is:

If we deploy project in different folders, so they have different absolute path, and then 
```
app.config.assets.version = [
        app.config.assets.version,
        'ART',
        Digest::MD5.hexdigest("#{VERSION}-#{app.config.angular_templates}")
      ].join '-'
```

will generate different digest value when do rake assets:precompile, this will make 404 Error if we deploy project to multi servers.

So if we set default value to relative path, then everything is ok