### PR TITLE
Use global Rails namespace in Sprockets templates

### DIFF
--- a/vendor/assets/javascripts/angular-rails-templates.js.erb
+++ b/vendor/assets/javascripts/angular-rails-templates.js.erb
@@ -1,8 +1,8 @@
 // Angular Rails Templates <%= AngularRailsTemplates::VERSION %>
 //
-// angular_templates.ignore_prefix: <%= Rails.configuration.angular_templates.ignore_prefix %>
-// angular_templates.markups: <%= Rails.configuration.angular_templates.markups %>
-// angular_templates.htmlcompressor: <%= Rails.configuration.angular_templates.htmlcompressor %>
+// angular_templates.ignore_prefix: <%= ::Rails.configuration.angular_templates.ignore_prefix %>
+// angular_templates.markups: <%= ::Rails.configuration.angular_templates.markups %>
+// angular_templates.htmlcompressor: <%= ::Rails.configuration.angular_templates.htmlcompressor %>
 
-angular.module("<%= Rails.configuration.angular_templates.module_name %>", []);
+angular.module("<%= ::Rails.configuration.angular_templates.module_name %>", []);
 


### PR DESCRIPTION
I'm have issue with Rails namespace in latest Sprockets/SprocketsRails.
This is permanent fix.