### PR TITLE
Update railties dependency to support Rails 7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           - rails_6.1
           - rails_7.0
           - rails_7.1
+          - rails_7.2
         include:
           - gemfile: rails_5.0
             ruby: '2.6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [Unreleased]
 
+### 1.2.2
+
+- Support Rails 7.2
+
 ### 1.2.1
 
 - Support Rails 7.1

--- a/angular-rails-templates.gemspec
+++ b/angular-rails-templates.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "railties", ">= 5.0", "< 7.2"
+  s.add_dependency "railties", ">= 5.0", "< 7.3"
   s.add_dependency "sprockets", ">= 3.0", '< 5'
   s.add_dependency "sprockets-rails"
   s.add_dependency "tilt"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.2.0"
+gem "slim-rails"
+gem "haml"
+gem "kramdown"
+
+gem 'coveralls', require: false
+
+gemspec :path => ".././"

--- a/lib/angular-rails-templates/version.rb
+++ b/lib/angular-rails-templates/version.rb
@@ -1,3 +1,3 @@
 module AngularRailsTemplates
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end


### PR DESCRIPTION
- allow rails 7.2.x
- run tests with ruby 3.1, 3.2 and 3.3