### PR TITLE
Rely on the digest class defined by Rails

### DIFF
--- a/lib/angular-rails-templates/engine.rb
+++ b/lib/angular-rails-templates/engine.rb
@@ -37,7 +37,12 @@ module AngularRailsTemplates
 
       # Sprockets Cache Busting
       # If ART's version or settings change, expire and recompile all assets
-      hash_digest = defined?(ActiveSupport::Digest) ? ActiveSupport::Digest : Digest::MD5
+      hash_digest = if defined?(ActiveSupport::Digest)
+                      app.config.active_support.hash_digest_class || ActiveSupport::Digest.hash_digest_class
+                    else
+                      Digest::MD5
+                    end
+
       app.config.assets.version = [
         app.config.assets.version,
         'ART',


### PR DESCRIPTION
Rails applications can override the digest class through configuration settings. Further, Rails does this by default in versions suchs as 7 where it defaults to SHA256. Using ActiveSupport::Digest directly skips over this setting causing it to always be MD5 in the current state. This breaks in modern environments MD5 is disabled such as FIPS environments.