### PR TITLE
Fix broken tests due to missing Logger

### DIFF
--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -2,4 +2,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require "logger" # Fix concurrent-ruby removing logger dependency which Rails itself does not have
 $LOAD_PATH.unshift File.expand_path('../../../../lib', __FILE__)


### PR DESCRIPTION
The failing tests are unrelated to https://github.com/pitr/angular-rails-templates/pull/173 and appear to be caused by a change in concurrent ruby and Rails.

See https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror